### PR TITLE
Make Slack notifications more concise

### DIFF
--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -138,9 +138,7 @@ class DeploymentsController < ApplicationController
   end
 
   def notify
-    project_names = @deployment.projects.map { |project| project.repository.name }.join(", ")
-    message = release_message(project_names, @deployment)
-    slack_post(channels, message)
+    slack_post(channels, release_message(@deployment))
   end
 
   def channels

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -29,8 +29,8 @@ module ReleasesHelper
     fallback_text = "##{deployment.id} (#{deployment.release.name}) #{deployment.status.name} to #{deployment.environment.name} by @#{current_username}: #{deploy_url}"
 
     payload = {
-      text:     msg_text,
       fallback: fallback_text,
+      text:     msg_text,
       color:    STATUS_TO_SLACK_COLOUR[deployment.status_id]
     }
 
@@ -42,7 +42,7 @@ module ReleasesHelper
       payload[:fields] = [
         {
             title: "Projects",
-            value: deployment.projects.map { |p| p.repository.name }.sort.join(", "),
+            value: deployment.projects.map { |p| p.repository.name }.join(", "),
             short: true
         }
       ]

--- a/spec/helpers/releases_helper_spec.rb
+++ b/spec/helpers/releases_helper_spec.rb
@@ -3,48 +3,76 @@ require "rails_helper"
 RSpec.describe ReleasesHelper, type: :helper do
   describe "#release_message" do
     let(:deployment) { create(:deployment) }
-    let(:project_names) { "Mobile,Desktop,App" }
+    let(:projects) { ["Mobile", "Desktop", "App"] }
+    let(:project_names) { "Mobile, Desktop, App" }
+    let(:deploy_url) { "https://test.host#{deployment_path(deployment)}" }
+    let(:release_url) { "https://test.host#{release_path(deployment.release)}" }
+    let(:text) do
+      "<#{deploy_url}|##{deployment.id}> (<#{release_url}|#{deployment.release.name}>) " \
+      "#{deployment.status.name} to #{deployment.environment.name} by @#{current_username}"
+    end
     let(:expected_message) do
       [{
-        fallback: "<https://test.host/deployments/#{deployment.id}|RR(deployment-#{deployment.id})> is \"#{deployment.status.name}\" by @releasehub cc #{deployment.notification_list}",
-        text: "<https://test.host/deployments/#{deployment.id}|RR(deployment-#{deployment.id})> is \"#{deployment.status.name}\" by @releasehub",
-        fields: fields,
-        color: nil
+        fallback: "##{deployment.id} (#{deployment.release.name}) #{deployment.status.name} to #{deployment.environment.name} by @#{current_username}: #{deploy_url}",
+        text: text,
+        color: nil,
+        fields: fields
       }].to_json
     end
+    let(:current_username) { "releasehub" }
 
     before do
-      allow(helper).to receive(:current_username).and_return("releasehub")
+      allow(helper).to receive(:current_username).and_return(current_username)
+      projects_array = []
+      allow(deployment).to receive(:projects).and_return(projects_array)
+      allow(projects_array).to receive(:map).and_return(projects)
+    end
+
+    context "when dev is the same as current username" do
+      let(:current_username) { deployment.dev }
+      let(:fields) do
+        [
+          { title: "Projects", value: project_names, short: true }
+        ]
+      end
+
+      it "does not include dev name" do
+        expect(helper.release_message(deployment)).to eq(expected_message)
+      end
     end
 
     context "when not to notify people" do
+      let(:text) do
+        "<#{deploy_url}|##{deployment.id}> (<#{release_url}|#{deployment.release.name}>) " \
+        "#{deployment.status.name} to #{deployment.environment.name} by @#{current_username} for @#{deployment.dev}"
+      end
       let(:fields) do
         [
-          { title: "Projects", value: project_names, short: true },
-          { title: "Environment", value: deployment.environment.name, short: true },
-          { title: "Dev", value: deployment.dev, short: true }
+          { title: "Projects", value: project_names, short: true }
         ]
       end
 
       it "does not include notification list" do
-        expect(helper.release_message(project_names, deployment)).to eq(expected_message)
+        expect(helper.release_message(deployment)).to eq(expected_message)
       end
     end
 
     context "when notify people" do
+      let(:text) do
+        "<#{deploy_url}|##{deployment.id}> (<#{release_url}|#{deployment.release.name}>) " \
+        "#{deployment.status.name} to #{deployment.environment.name} by @#{current_username} for @#{deployment.dev}"
+      end
       let(:fields) do
         [
           { title: "Projects", value: project_names, short: true },
-          { title: "Environment", value: deployment.environment.name, short: true },
-          { title: "Dev", value: deployment.dev, short: true },
-          { title: "Notification list", value: deployment.notification_list, short: true }
+          { title: "Notify", value: deployment.notification_list, short: true }
         ]
       end
 
       before { allow(deployment).to receive(:notify_people?).and_return(true) }
 
-      it "includes notification list" do
-        expect(helper.release_message(project_names, deployment)).to eq(expected_message)
+      it "includes Notify" do
+        expect(helper.release_message(deployment)).to eq(expected_message)
       end
     end
   end


### PR DESCRIPTION
* Compress the information sent to Slack, so it doesn't fill up a channel so much.
* Suppress even more information if state has changed recently. 
* Better formatting for the fallback option (no HTML).