### PR TITLE
PB-2068 Annotated tags refactor

### DIFF
--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -84,6 +84,8 @@ class DeploymentsController < ApplicationController
       case @deployment.status_id
       when Status::DEPLOYING
         @deployment.attach_deployment_tags(current_user, client)
+      when Status::ROLLBACK
+        @deployment.attach_deployment_tags(current_user, client) if previous_status == Status::DEPLOYED
       when Status::CANCELLED
         @deployment.detach_deployment_tags(client) if previous_status == Status::DEPLOYING
       end

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -13,7 +13,6 @@ class Deployment < ActiveRecord::Base
   attr_reader :api_client
 
   NOTIFY_STATUS = Set[Status::DEPLOYED, Status::ROLLBACK]
-  USER_EMAIL_DOMAIN = ENV["RH_USER_EMAIL_DOMAIN"]
 
   def repo_names
     projects.map { |project| project.repository.name }.join(",")
@@ -27,6 +26,10 @@ class Deployment < ActiveRecord::Base
     operation_logs.last
   end
 
+  def deploy(ops, api_client)
+    attach_deployment_tags(ops, api_client, "")
+  end
+
   def attach_deployment_tags(ops, api_client)
     @api_client ||= api_client
 
@@ -34,16 +37,17 @@ class Deployment < ActiveRecord::Base
 
     else
       projects.each do |project|
-        repo_name = project.repository.name
+        tag = Tag.new(project, ops)
 
-        annotated_tag = create_annotated_tag(project, ops)
-        if annotated_tag_referenced?(repo_name)
+        annotated_tag = create_annotated_tag(tag)
+
+        if annotated_tag_referenced?(tag.repo, tag.reference)
           update_annotated_tag_reference(
-            annotated_tag[:sha], repo_name
+            tag.repo, tag.reference, annotated_tag[:sha]
           )
         else
           create_annotated_tag_reference(
-            annotated_tag[:sha], repo_name
+            tag.repo, tag.reference, annotated_tag[:sha]
           )
         end
       end
@@ -56,63 +60,48 @@ class Deployment < ActiveRecord::Base
     if environment.production?
     else
       projects.each do |project|
-        repo_name = project.repository.name
-        delete_annotated_tag_reference(repo_name) if annotated_tag_referenced?(repo_name)
+        tag = Tag.new(project, ops)
+
+        delete_annotated_tag_reference(tag.repo, tag.reference) if annotated_tag_referenced?(tag.repo, tag.reference)
       end
     end
   end
 
   private
 
-  def create_annotated_tag(project, ops)
-    object_sha = project.sha
-    message = "#{project.branch.name}\n"
-    tagger_name = ops.name || "Ops".freeze
-    tagger_email = "#{ops.slack_username}@#{USER_EMAIL_DOMAIN}"
-    tagger_date = Time.now.utc.iso8601
-
-    tag_params = [
-      repo(project.repository.name),
-      tag_name,
-      message,
-      object_sha,
-      "commit".freeze,
-      tagger_name,
-      tagger_email,
-      tagger_date
-    ]
-
-    api_client.create_tag(*tag_params)
+  def create_annotated_tag(tag)
+    api_client.create_tag(*create_tag_params(tag))
   end
 
-  def create_annotated_tag_reference(tag_sha, repo_name)
-    api_client.create_ref(repo(repo_name), tag_ref, tag_sha)
+  def create_annotated_tag_reference(repo_name, tag_ref, tag_sha)
+    api_client.create_ref(repo_name, tag_ref, tag_sha)
   end
 
-  def update_annotated_tag_reference(tag_sha, repo_name)
-    api_client.update_ref(repo(repo_name), tag_ref, tag_sha)
+  def update_annotated_tag_reference(repo_name, tag_ref, tag_sha)
+    api_client.update_ref(repo_name, tag_ref, tag_sha)
   end
 
-  def delete_annotated_tag_reference(repo_name)
-    api_client.delete_ref(repo(repo_name), tag_ref)
+  def delete_annotated_tag_reference(repo_name, tag_ref)
+    api_client.delete_ref(repo_name, tag_ref)
   end
 
-  def annotated_tag_referenced?(repo_name)
-    api_client.ref(repo(repo_name), tag_ref)
+  def annotated_tag_referenced?(repo_name, tag_ref)
+    api_client.ref(repo_name, tag_ref)
     true
   rescue ::Octokit::NotFound
     return false
   end
 
-  def repo(name)
-    "#{ReleasesHelper::ORGANISATION}/#{name}"
-  end
-
-  def tag_name
-    "#{environment.name}_deployed"
-  end
-
-  def tag_ref
-    "tags/#{tag_name}"
+  def create_tag_params(tag)
+    [
+      tag.repo,
+      tag.name,
+      tag.message,
+      tag.sha,
+      "commit".freeze,
+      tag.tagger_name,
+      tag.tagger_email,
+      tag.date
+    ]
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,55 @@
+class Tag
+
+  USER_EMAIL_DOMAIN = ENV["RH_USER_EMAIL_DOMAIN"]
+
+  def initialize(project, ops)
+    @project = project
+    @ops = ops
+  end
+
+  def sha
+    @project.sha
+  end
+
+  def repo
+    "#{ReleasesHelper::ORGANISATION}/#{@project.repository.name}"
+  end
+
+  def message
+    "#{@project.branch.name}\n#{@project.deployment.release.summary}\n"
+  end
+
+  def tagger_name
+    @ops.name || "Ops".freeze
+  end
+
+  def tagger_email
+    "#{@ops.slack_username}@#{USER_EMAIL_DOMAIN}"
+  end
+
+  def date
+    Time.now.utc.iso8601
+  end
+
+  def status
+    @project.deployment.status.name
+  end
+
+  def name
+    "#{@project.deployment.environment.name}_#{Date.current}_#{tag_status(status)}"
+  end
+
+  def reference
+    "tags/#{name}"
+  end
+
+  private
+
+  def tag_status(status)
+    if status == "deploying"
+      status = "deployed"
+    end
+    status
+  end
+
+end


### PR DESCRIPTION
#### Overview

This PR adds annotated tagging when deploying or rolling back projects.

Note: refactors Chi's original PR https://github.com/globaldev/releasehub/pull/9, the main change is the ability to tag a rollback.  All the tag logic in the deployment model was confusing (for me anyway) so I have moved that to a Tag class.

### Example test tags

![screen shot 2017-07-04 at 13 45 22](https://user-images.githubusercontent.com/469041/27831606-4ddda18a-60c3-11e7-8667-f7ea729e9982.png)

![screen shot 2017-07-04 at 13 44 26](https://user-images.githubusercontent.com/469041/27831623-5b108386-60c3-11e7-9276-51ce9f4daf04.png)

#### Todo

- [x] Move all the tag specific logic from deployment model to a Tag class  
   - [x] Update release/tag title to `{env_name}_{date}_{status}` i.e. `qa1_2017-07-04_deployed`
   - [x] Create a tag on rollback i.e. `qa1_2017-07-04_rollback`
   - [x] Include the summary with the release message 
- [ ] Check / Test everything with @djlowens
- [ ] Production workflow tbc

FG: https://globalpersonals.atlassian.net/browse/WIN-875
PG: https://globalpersonals.atlassian.net/browse/PB-2068