### PR TITLE
Swap Slack Web API to use the Conversations endpoint instead of Channels - enforce public channels only

### DIFF
--- a/app/helpers/slack_helper.rb
+++ b/app/helpers/slack_helper.rb
@@ -5,7 +5,8 @@ module SlackHelper
   LOGO_URL = "https://dl.dropboxusercontent.com/u/44435189/releasehub-logo-48.png"
   SLACK_CHAT_URL = "https://slack.com/api/chat.postMessage"
   SLACK_USER_LIST_URL = "https://slack.com/api/users.list"
-  SLACK_CHANNEL_LIST_URL = "https://slack.com/api/channels.list"
+  SLACK_CHANNEL_LIST_URL = "https://slack.com/api/conversations.list"
+  SLACK_CHANNEL_TYPES = "public_channel"
 
   def slack_post(channels, message)
     uri = URI.parse(SLACK_CHAT_URL)
@@ -29,7 +30,7 @@ module SlackHelper
       users = JSON.parse(res.body)["members"].map{ |member| {"name" => "@#{member["name"]}"} }
 
       uri = URI.parse(SLACK_CHANNEL_LIST_URL)
-      res = Net::HTTP.post_form(uri, "token" => SLACK_TOKEN, "exclude_archived" => 1)
+      res = Net::HTTP.post_form(uri, "token" => SLACK_TOKEN, "exclude_archived" => 1, "types" => SLACK_CHANNEL_TYPES)
       channels = JSON.parse(res.body)["channels"].map{ |channel| {"name" => "##{channel["name"]}"} }
 
       (users + channels).to_json


### PR DESCRIPTION
Swap Slack Web API to use the Conversations endpoint instead of Channels - enforce public channels only.

Fixes the following RH issue:
```
I, [2021-02-25T12:27:30.198010 #39824]  INFO -- : Completed 500 Internal Server Error in 1069ms (ActiveRecord: 28.0ms)
F, [2021-02-25T12:27:30.199098 #39824] FATAL -- :
ActionView::Template::Error (undefined method `map' for nil:NilClass):
    104:     });
    105:
    106:     $('input.notify.typeahead').typeahead({
    107:       source: #{slack_notify_list},
    108:       autoSelect: true,
    109:       limit: 10,
    110:       updater: function(item){
  app/helpers/slack_helper.rb:33:in `block in slack_notify_list'
  app/helpers/slack_helper.rb:26:in `slack_notify_list'
  app/views/deployments/new.html.haml:107:in `_app_views_deployments_new_html_haml___4163111291469076117_47136687510380'
```